### PR TITLE
[feat] 블로그 조회 수 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 	//DB
 	implementation 'mysql:mysql-connector-java:8.0.33'
 
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/cobo/blog/BlogApplication.java
+++ b/src/main/java/cobo/blog/BlogApplication.java
@@ -2,8 +2,10 @@ package cobo.blog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BlogApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/cobo/blog/domain/All/AllController.java
+++ b/src/main/java/cobo/blog/domain/All/AllController.java
@@ -1,0 +1,37 @@
+package cobo.blog.domain.All;
+
+import cobo.blog.domain.About.Data.Dto.AboutMemberRes;
+import cobo.blog.domain.All.Data.Dto.AllHitRes;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/all")
+@AllArgsConstructor
+@Api(tags = {"05. 모든 화면에 사용하는 API"})
+public class AllController {
+
+    private final AllServiceImpl allService;
+
+    @GetMapping("/hit")
+    @ApiOperation(
+            value = "블로그의 조회 수를 가져온다,",
+            notes = "today 오늘 조회수, total 전체 조회수(오늘 조회도 합친)",
+            response = AllHitRes.class
+    )
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "응답 성공")
+    })
+    public ResponseEntity<AllHitRes> Test(){
+        return allService.getHit();
+    }
+}

--- a/src/main/java/cobo/blog/domain/All/AllController.java
+++ b/src/main/java/cobo/blog/domain/All/AllController.java
@@ -8,10 +8,13 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
 
+import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 
 @RestController
@@ -31,7 +34,9 @@ public class AllController {
     @ApiResponses({
             @ApiResponse(code = 200, message = "응답 성공")
     })
-    public ResponseEntity<AllHitRes> Test(){
-        return allService.getHit();
+    public ResponseEntity<AllHitRes> hit(
+            @ApiIgnore @CookieValue(value = "hitCookie", defaultValue = "0") Integer hitCookie,
+            HttpServletResponse httpServletResponse){
+        return allService.getHit(hitCookie, httpServletResponse);
     }
 }

--- a/src/main/java/cobo/blog/domain/All/AllServiceImpl.java
+++ b/src/main/java/cobo/blog/domain/All/AllServiceImpl.java
@@ -1,0 +1,28 @@
+package cobo.blog.domain.All;
+
+import cobo.blog.domain.All.Data.Dto.AllHitRes;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+@Service
+@Slf4j
+@AllArgsConstructor
+public class AllServiceImpl {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public ResponseEntity<AllHitRes> getHit(){
+
+        Long today = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue().get("today")));
+        Long total = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue().get("total")));
+
+        redisTemplate.opsForValue().increment("today");
+
+        return new ResponseEntity<>(new AllHitRes(today, today + total), HttpStatus.OK);
+    }
+}

--- a/src/main/java/cobo/blog/domain/All/AllServiceImpl.java
+++ b/src/main/java/cobo/blog/domain/All/AllServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 
@@ -16,6 +17,7 @@ import java.util.Objects;
 public class AllServiceImpl {
     private final RedisTemplate<String, String> redisTemplate;
 
+    @Transactional
     public ResponseEntity<AllHitRes> getHit(){
 
         Long today = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue().get("today")));

--- a/src/main/java/cobo/blog/domain/All/AllServiceImpl.java
+++ b/src/main/java/cobo/blog/domain/All/AllServiceImpl.java
@@ -1,6 +1,7 @@
 package cobo.blog.domain.All;
 
 import cobo.blog.domain.All.Data.Dto.AllHitRes;
+import io.swagger.models.auth.In;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -25,15 +26,16 @@ public class AllServiceImpl {
         Long today = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue().get("today")));
         Long total = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue().get("total")));
 
-        if(hitCookie == 0){
-            redisTemplate.opsForValue().increment("today");
-
-            Cookie cookie = new Cookie("hitCookie", "1");
-            cookie.setMaxAge(900);
-            httpServletResponse.addCookie(cookie);
-        }
-
+        if(hitCookie == 0) IncrementTodayAndSetCookie(httpServletResponse);
 
         return new ResponseEntity<>(new AllHitRes(today, today + total), HttpStatus.OK);
+    }
+
+    private void IncrementTodayAndSetCookie(HttpServletResponse httpServletResponse){
+        redisTemplate.opsForValue().increment("today");
+
+        Cookie cookie = new Cookie("hitCookie", "1");
+        cookie.setMaxAge(900);
+        httpServletResponse.addCookie(cookie);
     }
 }

--- a/src/main/java/cobo/blog/domain/All/AllServiceImpl.java
+++ b/src/main/java/cobo/blog/domain/All/AllServiceImpl.java
@@ -9,6 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 import java.util.Objects;
 
 @Service
@@ -18,12 +20,19 @@ public class AllServiceImpl {
     private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional
-    public ResponseEntity<AllHitRes> getHit(){
+    public ResponseEntity<AllHitRes> getHit(Integer hitCookie, HttpServletResponse httpServletResponse){
 
         Long today = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue().get("today")));
         Long total = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue().get("total")));
 
-        redisTemplate.opsForValue().increment("today");
+        if(hitCookie == 0){
+            redisTemplate.opsForValue().increment("today");
+
+            Cookie cookie = new Cookie("hitCookie", "1");
+            cookie.setMaxAge(900);
+            httpServletResponse.addCookie(cookie);
+        }
+
 
         return new ResponseEntity<>(new AllHitRes(today, today + total), HttpStatus.OK);
     }

--- a/src/main/java/cobo/blog/domain/All/Data/Dto/AllHitRes.java
+++ b/src/main/java/cobo/blog/domain/All/Data/Dto/AllHitRes.java
@@ -1,0 +1,22 @@
+package cobo.blog.domain.All.Data.Dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AllHitRes {
+
+    @ApiModelProperty(
+            value = "블로그 오늘 조회수",
+            example = "1"
+    )
+    private Long today;
+
+    @ApiModelProperty(
+            value = "블로그 전체 조회수",
+            example = "1020303"
+    )
+    private Long total;
+}

--- a/src/main/java/cobo/blog/domain/Tech/Data/Dto/TechTechPostRes.java
+++ b/src/main/java/cobo/blog/domain/Tech/Data/Dto/TechTechPostRes.java
@@ -40,6 +40,12 @@ public class TechTechPostRes {
     private String content;
 
     @ApiModelProperty(
+            value = "해당 포스트의 조회 수",
+            example = "123"
+    )
+    private Long viewCount;
+
+    @ApiModelProperty(
             value = "해당 TechPost의 url",
             example = "https://seungkyu-han.tistory.com/"
     )
@@ -55,5 +61,6 @@ public class TechTechPostRes {
         for(TechPostSkillTagMappingEntity techPostSkillTagMappingEntity : techPostEntity.getTechPostSkillTagMappings())
             this.skillTag.add(techPostSkillTagMappingEntity.getSkillTag().getName());
         this.url = techPostEntity.getUrl();
+        this.viewCount = techPostEntity.getViewCount();
     }
 }

--- a/src/main/java/cobo/blog/global/Config/RedisConfig.java
+++ b/src/main/java/cobo/blog/global/Config/RedisConfig.java
@@ -1,0 +1,35 @@
+package cobo.blog.global.Config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/cobo/blog/global/Data/Entity/HitEntity.java
+++ b/src/main/java/cobo/blog/global/Data/Entity/HitEntity.java
@@ -1,0 +1,32 @@
+package cobo.blog.global.Data.Entity;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Entity
+@Table(name = "hit")
+@NoArgsConstructor
+@Data
+public class HitEntity {
+
+    @Id
+    private String date;
+
+    private Long today;
+
+    private Long total;
+
+    public HitEntity(Long today, Long total) {
+        this.date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        this.today = today;
+        this.total = total;
+    }
+
+}

--- a/src/main/java/cobo/blog/global/Data/Entity/TechPostEntity.java
+++ b/src/main/java/cobo/blog/global/Data/Entity/TechPostEntity.java
@@ -25,6 +25,8 @@ public class TechPostEntity {
 
     private String url;
 
+    private Long viewCount;
+
     @ManyToOne
     @JoinColumn(name = "user")
     private UserEntity user;

--- a/src/main/java/cobo/blog/global/Repository/HitRepository.java
+++ b/src/main/java/cobo/blog/global/Repository/HitRepository.java
@@ -1,0 +1,9 @@
+package cobo.blog.global.Repository;
+
+import cobo.blog.global.Data.Entity.HitEntity;
+import cobo.blog.global.Data.Entity.ProjectEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HitRepository extends JpaRepository<HitEntity, String> {
+
+}

--- a/src/main/java/cobo/blog/global/Repository/Redis/RedisToDbScheduler.java
+++ b/src/main/java/cobo/blog/global/Repository/Redis/RedisToDbScheduler.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
 
@@ -20,6 +21,7 @@ public class RedisToDbScheduler {
     private HitRepository hitRepository;
 
     @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
     public void saveHitToDB(){
 
         log.info("조회수 반영");

--- a/src/main/java/cobo/blog/global/Repository/Redis/RedisToDbScheduler.java
+++ b/src/main/java/cobo/blog/global/Repository/Redis/RedisToDbScheduler.java
@@ -1,0 +1,39 @@
+package cobo.blog.global.Repository.Redis;
+
+import cobo.blog.global.Data.Entity.HitEntity;
+import cobo.blog.global.Repository.HitRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+@Component
+@AllArgsConstructor
+@Slf4j
+public class RedisToDbScheduler {
+
+    private RedisTemplate<String, String> redisTemplate;
+    private HitRepository hitRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void saveHitToDB(){
+
+        log.info("조회수 반영");
+
+        Long today = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue().get("today")));
+        Long total = Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue().get("total")));
+
+        HitEntity hitEntity = new HitEntity(today, total);
+
+        redisTemplate.opsForValue().set("total", String.valueOf(today + total));
+        redisTemplate.opsForValue().set("today", String.valueOf(0));
+
+        log.info("today: {}. total: {}", today, today + total);
+
+        hitRepository.save(hitEntity);
+    }
+}


### PR DESCRIPTION
- 블로그의 조회 수를 가져올 수 있는 API 추가
- 해당 API를 호출 할 때마다 조회수 + 1
- 해당 조회수는 redis에서 하루에 한 번 db로 저장